### PR TITLE
Make Debian sources.list file configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,7 @@
 # package mirror url list
 # default is defined in vars
 pkg_mirror_url_list: '{{ pkg_mirror_url_list_default }}'
+
+# package mirror list filename
+# default is defined in vars
+pkg_mirror_sources_file: '{{ pkg_mirror_sources_file_default }}'

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -16,4 +16,4 @@ pkg_mirror_url_list_default:
   - 'deb-src https://pkg.adfinis-sygroup.ch/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }}-updates main contrib non-free'
 
 # sources filename
-pkg_mirror_sources_file: /etc/apt/sources.list
+pkg_mirror_sources_file_default: /etc/apt/sources.list

--- a/vars/Ubuntu_14.yml
+++ b/vars/Ubuntu_14.yml
@@ -18,4 +18,4 @@ pkg_mirror_url_list_default:
   - 'deb-src https://pkg.adfinis-sygroup.ch/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }}-backports main restricted universe multiverse'
 
 # sources filename
-pkg_mirror_sources_file: /etc/apt/sources.list
+pkg_mirror_sources_file_default: /etc/apt/sources.list

--- a/vars/Ubuntu_16.yml
+++ b/vars/Ubuntu_16.yml
@@ -18,4 +18,4 @@ pkg_mirror_url_list_default:
   - 'deb-src https://pkg.adfinis-sygroup.ch/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }}-backports main restricted universe multiverse'
 
 # sources filename
-pkg_mirror_sources_file: /etc/apt/sources.list
+pkg_mirror_sources_file_default: /etc/apt/sources.list

--- a/vars/Ubuntu_18.yml
+++ b/vars/Ubuntu_18.yml
@@ -18,4 +18,4 @@ pkg_mirror_url_list_default:
   - 'deb-src https://pkg.adfinis-sygroup.ch/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }}-backports main restricted universe multiverse'
 
 # sources filename
-pkg_mirror_sources_file: /etc/apt/sources.list
+pkg_mirror_sources_file_default: /etc/apt/sources.list


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The role would currently always overwrite `/etc/apt/sources.list` on Debian, even when explicitly setting `pkg_mirror_sources_file`, as this would later be overridden in `include_vars`.

This PR splits this variable into `pkg_mirror_sources_file_default` (loaded in include_vars) and `pkg_mirror_sources_file` (defaulting to `_default`, but overridable), making the file the sources are written to configurable.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.8.6
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['~/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.4 (default, Oct  4 2019, 06:57:26) [GCC 9.2.0]

```


