### PR TITLE
Add installation of APT PGP keys

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -10,6 +10,13 @@
   register: pkg_mirror_register_apt_repository
   when: ansible_os_family == 'Debian'
 
+- name: add apt keys
+  apt_key:
+    url: '{{ pkg_mirror_gpgkey_url }}'
+  when:
+    - ansible_os_family == 'Debian'
+    - pkg_mirror_gpgkey_url is defined
+
 - name: pkg_mirror reload apt cache
   apt:
     update_cache: yes


### PR DESCRIPTION
##### SUMMARY

Add optional installation of APT PGP keys for Debian/Ubuntu hosts.

Define e.g.
```
pkg_mirror_gpgkey_url: https://repo.example.com/key.gpg
```
in your host or group vars to have the key installed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.8.6
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['~/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.4 (default, Oct  4 2019, 06:57:26) [GCC 9.2.0]
```
