### PR TITLE
Support parallel os family configs for pkg_mirror_url_list

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,14 @@
 # default is defined in vars
 pkg_mirror_url_list: '{{ pkg_mirror_url_list_default }}'
 
+# package mirror url list (debian specific)
+# overwrites 'pkg_mirror_url_list'
+pkg_mirror_url_list_debian: []
+
+# package mirror url list (redhat specific)
+# overwrites 'pkg_mirror_url_list'
+pkg_mirror_url_list_redhat: []
+
 # package mirror list filename
 # default is defined in vars
 pkg_mirror_sources_file: '{{ pkg_mirror_sources_file_default }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,26 @@
     - 'role::pkg_mirror:install'
     - 'role::pkg_mirror:config'
 
+- name: set package url list debian
+  set_fact:
+      pkg_mirror_url_list: '{{ pkg_mirror_url_list_debian }}'
+  when:
+    - pkg_mirror_url_list_debian | length > 0
+    - ansible_os_family == 'Debian'
+  tags:
+    - 'role::pkg_mirror'
+    - 'role::pkg_mirror:install'
+
+- name: set package url list redhat
+  set_fact:
+      pkg_mirror_url_list: '{{ pkg_mirror_url_list_redhat }}'
+  when:
+    - pkg_mirror_url_list_redhat | length > 0
+    - ansible_os_family == 'Redhat'
+  tags:
+    - 'role::pkg_mirror'
+    - 'role::pkg_mirror:install'
+
 - import_tasks: installation.yml
   tags:
     - 'role::pkg_mirror'


### PR DESCRIPTION
##### SUMMARY
I'm not quite sure if this is the right way to do it, but it allows defining mirror_url_lists for both debian & redhat at the same time.
In a group_vars config this comes in very handy.

##### ISSUE TYPE
 - Feature Pull Request

