### PR TITLE
fix python-apt pkg name in Debian 11 (bullseye)

### DIFF
--- a/vars/Debian_11.yml
+++ b/vars/Debian_11.yml
@@ -1,0 +1,19 @@
+---
+
+# pkg-mirror packages
+pkg_mirror_packages:
+  - apt-transport-https
+  - python3-apt
+  - ca-certificates
+
+# pkg-mirror
+pkg_mirror_url_list_default:
+  - 'deb https://pkg.adfinis-sygroup.ch/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }} main contrib non-free'
+  - 'deb-src https://pkg.adfinis-sygroup.ch/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }} main non-free contrib'
+  - 'deb http://security.debian.org/ {{ ansible_distribution_release | lower }}/updates main contrib non-free'
+  - 'deb-src http://security.debian.org/ {{ ansible_distribution_release | lower }}/updates main contrib non-free'
+  - 'deb https://pkg.adfinis-sygroup.ch/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }}-updates main contrib non-free'
+  - 'deb-src https://pkg.adfinis-sygroup.ch/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }}-updates main contrib non-free'
+
+# sources filename
+pkg_mirror_sources_file_default: /etc/apt/sources.list


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
python-apt was renamed to python3-apt in Debian 11 Bullseye
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request