### PR TITLE
Fix Debian 11 apt mirrorlist

### DIFF
--- a/vars/Debian_11.yml
+++ b/vars/Debian_11.yml
@@ -10,8 +10,8 @@ pkg_mirror_packages:
 pkg_mirror_url_list_default:
   - 'deb https://pkg.adfinis-sygroup.ch/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }} main contrib non-free'
   - 'deb-src https://pkg.adfinis-sygroup.ch/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }} main non-free contrib'
-  - 'deb http://security.debian.org/ {{ ansible_distribution_release | lower }}/updates main contrib non-free'
-  - 'deb-src http://security.debian.org/ {{ ansible_distribution_release | lower }}/updates main contrib non-free'
+  - 'deb http://security.debian.org/debian-security {{ ansible_distribution_release | lower }}-security main contrib non-free'
+  - 'deb-src http://security.debian.org/debian-security {{ ansible_distribution_release | lower }}-security main contrib non-free'
   - 'deb https://pkg.adfinis-sygroup.ch/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }}-updates main contrib non-free'
   - 'deb-src https://pkg.adfinis-sygroup.ch/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }}-updates main contrib non-free'
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Before I made this change, `apt update` wasn't possible and resulted in this message:
```
Ign:1 http://security.debian.org bullseye/updates InRelease
Err:2 http://security.debian.org bullseye/updates Release
  404  Not Found [IP: 2a04:4e42:65::644 80]
Hit:3 https://pkg.adfinis-sygroup.ch/debian bullseye InRelease
Hit:4 https://pkg.adfinis-sygroup.ch/debian bullseye-updates InRelease
Reading package lists... Done
E: The repository 'http://security.debian.org bullseye/updates Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.9.23
  python version = 2.7.16 (default, Oct 10 2019, 22:02:15) [GCC 8.3.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
