### PR TITLE
fix(debian): add gpg package dependency

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -5,6 +5,7 @@ pkg_mirror_packages:
   - apt-transport-https
   - python3-apt
   - ca-certificates
+  - gpg
 
 # pkg-mirror
 pkg_mirror_url_list_default:

--- a/vars/Debian_10.yml
+++ b/vars/Debian_10.yml
@@ -5,6 +5,7 @@ pkg_mirror_packages:
   - apt-transport-https
   - python-apt
   - ca-certificates
+  - gpg
 
 # pkg-mirror
 pkg_mirror_url_list_default:


### PR DESCRIPTION
##### SUMMARY
Add package `gpg` to be installed, as it's required for Debian to be able to import the apt keys. If it's not installed the following error will appear:

```
TASK [adfinis.pkg_mirror : Add apt keys] *****************************************************************************************************************************************************************************************************
task path: monitoring-plays/adfinis-roles/adfinis.pkg_mirror/tasks/configuration.yml:12
fatal: FAILED! => {"changed": false, "msg": "Failed to find required executable \"gpg\" in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible [core 2.14.3]
  ansible python module location = /usr/lib/python3/dist-packages/ansible
  ansible collection location = .ansible/collections:/usr/share/ansible/collections
  executable location = /usr/bin/ansible
  python version = 3.11.2 (main, Mar 13 2023, 12:18:29) [GCC 12.2.0] (/usr/bin/python3)
  jinja version = 3.1.2
  libyaml = True
```
