### PR TITLE
Add backwards-compatible way for storing GPG keys outside of trusted.gpg and add functionality to add credentials to auth.conf.d

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ pkg_mirror_sources_file: /etc/apt/sources.list.d/<filename>.list
 pkg_mirror_url_list_debian:
  - 'deb <repo url>/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release }} main'
 pkg_mirror_auth_entries:
-    - auth_machine: <repo hostname>
-      auth_login: <repo username>
-      auth_password: <repo password>
+ - auth_machine: <repo hostname>
+   auth_login: <repo username>
+   auth_password: <repo password>
 
 pkg_mirror_url_list_redhat:
  - name: '<repo name>'

--- a/README.md
+++ b/README.md
@@ -17,9 +17,14 @@ Manage system package sources
 
 ```yaml
 pkg_mirror_gpgkey_url: '<gpg url>'
+pkg_mirror_gpg_directory: '<apt trusted gpg directory>'
 pkg_mirror_sources_file: /etc/apt/sources.list.d/<filename>.list
 pkg_mirror_url_list_debian:
  - 'deb <repo url>/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release }} main'
+pkg_mirror_auth_entries:
+    - auth_machine: <repo hostname>
+      auth_login: <repo username>
+      auth_password: <repo password>
 
 pkg_mirror_url_list_redhat:
  - name: '<repo name>'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,8 @@ pkg_mirror_url_list_suse: []
 # package mirror list filename
 # default is defined in vars
 pkg_mirror_sources_file: "{{ pkg_mirror_sources_file_default }}"
+# trusted gpg directory
+# default is defined in vars
+pkg_mirror_gpg_directory: "{{ pkg_mirror_gpg_directory_default }}"
+# apt auth config entries
+pkg_mirror_auth_entries: []

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -12,11 +12,20 @@
 - name: Download apt key
   ansible.builtin.get_url:
     url: "{{ pkg_mirror_gpgkey_url }}"
-    dest: "/etc/apt/trusted.gpg.d/{{ pkg_mirror_gpgkey_url | basename }}"
+    dest: "{{ pkg_mirror_gpg_directory }}/{{ pkg_mirror_gpgkey_url | basename }}"
     mode: "0644"
   when:
     - ansible_os_family == 'Debian'
     - pkg_mirror_gpgkey_url is defined
+
+- name: Configure auth for pkg mirror
+  ansible.builtin.template:
+    src: "etc/apt/auth.conf.j2"
+    dest: "/etc/apt/auth.conf.d/{{ auth_machine }}.conf"
+    mode: "0644"
+  with_items: "{{ pkg_mirror_auth_entries }}"
+  when:
+    - pkg_mirror_auth_entries | length > 0
 
 - name: Pkg_mirror reload apt cache
   ansible.builtin.apt:

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -21,7 +21,7 @@
 - name: Configure auth for pkg mirror
   ansible.builtin.template:
     src: "etc/apt/auth.conf.j2"
-    dest: "/etc/apt/auth.conf.d/{{ auth_machine }}.conf"
+    dest: "/etc/apt/auth.conf.d/{{ item.auth_machine }}.conf"
     mode: "0644"
   with_items: "{{ pkg_mirror_auth_entries }}"
   when:

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -9,9 +9,11 @@
   register: pkg_mirror_register_apt_repository
   when: ansible_os_family == 'Debian'
 
-- name: Add apt keys
-  ansible.builtin.apt_key:
+- name: Download apt key
+  ansible.builtin.get_url:
     url: "{{ pkg_mirror_gpgkey_url }}"
+    dest: "/etc/apt/keyrings/{{ pkg_mirror_gpgkey_url | basename }}"
+    mode: "0644"
   when:
     - ansible_os_family == 'Debian'
     - pkg_mirror_gpgkey_url is defined

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -12,7 +12,7 @@
 - name: Download apt key
   ansible.builtin.get_url:
     url: "{{ pkg_mirror_gpgkey_url }}"
-    dest: "/etc/apt/keyrings/{{ pkg_mirror_gpgkey_url | basename }}"
+    dest: "/etc/apt/trusted.gpg.d/{{ pkg_mirror_gpgkey_url | basename }}"
     mode: "0644"
   when:
     - ansible_os_family == 'Debian'

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -23,7 +23,7 @@
   ansible.builtin.template:
     src: "etc/apt/auth.conf.j2"
     dest: "/etc/apt/auth.conf.d/{{ item.auth_machine }}.conf"
-    mode: "0644"
+    mode: "0600"
   register: pkg_mirror_register_auth
   with_items: "{{ pkg_mirror_auth_entries }}"
   when:

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -14,6 +14,7 @@
     url: "{{ pkg_mirror_gpgkey_url }}"
     dest: "{{ pkg_mirror_gpg_directory }}/{{ pkg_mirror_gpgkey_url | basename }}"
     mode: "0644"
+  register: pkg_mirror_download_apt_key
   when:
     - ansible_os_family == 'Debian'
     - pkg_mirror_gpgkey_url is defined
@@ -23,8 +24,10 @@
     src: "etc/apt/auth.conf.j2"
     dest: "/etc/apt/auth.conf.d/{{ item.auth_machine }}.conf"
     mode: "0644"
+  register: pkg_mirror_register_auth
   with_items: "{{ pkg_mirror_auth_entries }}"
   when:
+    - ansible_os_family == 'Debian'
     - pkg_mirror_auth_entries | length > 0
 
 - name: Pkg_mirror reload apt cache
@@ -32,7 +35,9 @@
     update_cache: true
   tags:
     - skip_ansible_lint
-  when: pkg_mirror_register_apt_repository is defined and pkg_mirror_register_apt_repository.changed
+  when: (pkg_mirror_register_apt_repository is defined and pkg_mirror_register_apt_repository.changed) or
+        (pkg_mirror_register_auth is defined and pkg_mirror_register_auth.changed) or
+        (pkg_mirror_download_apt_key is defined and pkg_mirror_download_apt_key.changed)
 
 - name: Configure yum repository
   ansible.builtin.yum_repository:

--- a/templates/etc/apt/auth.conf.j2
+++ b/templates/etc/apt/auth.conf.j2
@@ -1,3 +1,3 @@
-machine {{ auth_host }}
-login {{ auth_login }}
-password {{ auth_password }}
+machine {{ item.auth_machine }}
+login {{ item.auth_login }}
+password {{ item.auth_password }}

--- a/templates/etc/apt/auth.conf.j2
+++ b/templates/etc/apt/auth.conf.j2
@@ -1,0 +1,3 @@
+machine {{ auth_host }}
+login {{ auth_login }}
+password {{ auth_password }}

--- a/templates/etc/apt/sources.list.j2
+++ b/templates/etc/apt/sources.list.j2
@@ -2,5 +2,9 @@
 # {{ pkg_mirror_sources_file }}
 
 {% for line in pkg_mirror_url_list %}
-{{ line }}
+{% if pkg_mirror_gpgkey_url is defined %}
+deb [signed-by=/etc/apt/keyrings/{{ pkg_mirror_gpgkey_url | basename }}] {{ line | regex_replace('^deb ', '') }}
+{% else %}
+{{ line }
+{% endif %}
 {% endfor %}

--- a/templates/etc/apt/sources.list.j2
+++ b/templates/etc/apt/sources.list.j2
@@ -5,6 +5,6 @@
 {% if pkg_mirror_gpgkey_url is defined %}
 deb [signed-by=/etc/apt/keyrings/{{ pkg_mirror_gpgkey_url | basename }}] {{ line | regex_replace('^deb ', '') }}
 {% else %}
-{{ line }
+{{ line }}
 {% endif %}
 {% endfor %}

--- a/templates/etc/apt/sources.list.j2
+++ b/templates/etc/apt/sources.list.j2
@@ -3,7 +3,7 @@
 
 {% for line in pkg_mirror_url_list %}
 {% if pkg_mirror_gpgkey_url is defined %}
-deb [signed-by=/etc/apt/keyrings/{{ pkg_mirror_gpgkey_url | basename }}] {{ line | regex_replace('^deb ', '') }}
+deb [signed-by=/etc/apt/trusted.gpg.d/{{ pkg_mirror_gpgkey_url | basename }}] {{ line | regex_replace('^deb ', '') }}
 {% else %}
 {{ line }}
 {% endif %}

--- a/templates/etc/apt/sources.list.j2
+++ b/templates/etc/apt/sources.list.j2
@@ -3,7 +3,7 @@
 
 {% for line in pkg_mirror_url_list %}
 {% if pkg_mirror_gpgkey_url is defined %}
-deb [signed-by=/etc/apt/trusted.gpg.d/{{ pkg_mirror_gpgkey_url | basename }}] {{ line | regex_replace('^deb ', '') }}
+deb [signed-by={{ pkg_mirror_gpg_directory }}/{{ pkg_mirror_gpgkey_url | basename }}] {{ line | regex_replace('^deb ', '') }}
 {% else %}
 {{ line }}
 {% endif %}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -18,3 +18,6 @@ pkg_mirror_url_list_default:
 
 # sources filename
 pkg_mirror_sources_file_default: /etc/apt/sources.list
+
+# trusted gpg
+pkg_mirror_gpg_directory_default: /etc/apt/trusted.gpg.d

--- a/vars/Debian_10.yml
+++ b/vars/Debian_10.yml
@@ -18,3 +18,6 @@ pkg_mirror_url_list_default:
 
 # sources filename
 pkg_mirror_sources_file_default: /etc/apt/sources.list
+
+# trusted gpg
+pkg_mirror_gpg_directory: /etc/apt/trusted.gpg.d

--- a/vars/Debian_10.yml
+++ b/vars/Debian_10.yml
@@ -20,4 +20,4 @@ pkg_mirror_url_list_default:
 pkg_mirror_sources_file_default: /etc/apt/sources.list
 
 # trusted gpg
-pkg_mirror_gpg_directory: /etc/apt/trusted.gpg.d
+pkg_mirror_gpg_directory_default: /etc/apt/trusted.gpg.d


### PR DESCRIPTION
##### SUMMARY
This fixes the long-open issue #19 and finally should get rid of the `deprecated` warnings when running `apt update`.

As we pass the debian mirror URL config lines via a variable and do not dynamically template them, there was the need for a (very) ugly workaround of chopping of the `deb ` part of the line, adding a `[signed-by=xyz]` and templating in the rest to ensure backwards-compatibility. A nicer approach for this would just be to change the way these entries are handled, but this would introduce breaking changes, which we probably want to prevent.

##### ISSUE TYPE
 - Feature Pull Request

##### ANSIBLE VERSION
```
ansible [core 2.14.3]
```
##### ADDITIONAL INFORMATION
These changes have been tested on an example host.
