### PR TITLE
fix: deb822_repository task invocation

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -8,10 +8,8 @@
     suites: "{{ item.suite }}"
     components: "{{ item.components }}"
     signed_by: "{{ item.signed_by }}"
-    owner: root
-    group: root
     mode: "0644"
-  loop: "pkg_mirror_url_list"
+  loop: "{{ pkg_mirror_url_list }}"
   register: pkg_mirror_register_apt_repository
   when:
     - ansible_os_family == 'Debian'


### PR DESCRIPTION
##### SUMMARY
Fix for bugs introduced in #34 

##### ISSUE TYPE
 - Bugfix Pull Request

##### ANSIBLE VERSION
```
ansible [core 2.19.4]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['~/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible/lib/python3.11/site-packages/ansible
  ansible collection location = ~/.ansible/collections:/usr/share/ansible/collections
  executable location = /opt/ansible/bin/ansible
  python version = 3.11.2 (main, Apr 28 2025, 14:11:48) [GCC 12.2.0] (/opt/ansible/bin/python3)
  jinja version = 3.1.6
  pyyaml version = 6.0.3 (with libyaml v0.2.5)
```
