### PR TITLE
Draft: Update role to work with current supported major OS versions

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Configure apt repository
+- name: Configure apt repository for Debian 13 or higher and Ubuntu
   ansible.builtin.deb822_repository:
     name: "{{ item.name }}"
     types: "{{ item.types | default(['deb']) }}"
@@ -15,7 +15,7 @@
     - ansible_os_family == 'Debian'
     - ansible_distribution_major_version | int >= 13
 
-- name: Configure apt repository
+- name: Configure apt repository for Debian 12 or lower
   ansible.builtin.template:
     src: etc/apt/sources.list.j2
     dest: "{{ pkg_mirror_sources_file }}"
@@ -27,7 +27,7 @@
     - ansible_os_family == 'Debian'
     - ansible_distribution_major_version | int < 13
 
-- name: Download apt key
+- name: Download apt key for Debian 12 or lower
   ansible.builtin.get_url:
     url: "{{ pkg_mirror_gpgkey_url }}"
     dest: "{{ pkg_mirror_gpg_directory }}/{{ pkg_mirror_gpgkey_url | basename }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
     - "{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml"
+    - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"
   tags:
     - role::pkg_mirror

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -3,8 +3,8 @@
 # pkg-mirror packages
 pkg_mirror_packages:
   - apt-transport-https
-  - python-apt
   - ca-certificates
+  - python3-debian
 
 # pkg-mirror
 pkg_mirror_url_list_default:


### PR DESCRIPTION
##### SUMMARY
This PR should ensure that this role works on the following OS major versions:

* Debian 12
* Debian 13
* Ubuntu 24.04
* RHEL 8
* RHEL 9
* SLES 15


##### ISSUE TYPE
 - Feature Pull Request

##### ANSIBLE VERSION
Likely target:
```
ansible [core 2.20.1]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/saschad/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible/lib/python3.13/site-packages/ansible
  ansible collection location = /home/saschad/.ansible/collections:/usr/share/ansible/collections
  executable location = /opt/ansible/bin/ansible
  python version = 3.13.5 (main, Jun 25 2025, 18:55:22) [GCC 14.2.0] (/opt/ansible/bin/python3)
  jinja version = 3.1.6
  pyyaml version = 6.0.3 (with libyaml v0.2.5)

```


##### ADDITIONAL INFORMATION
